### PR TITLE
chore: add mergify auto-merge for renovate PRs

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,24 @@
+pull_request_rules:
+  - name: label conflicts
+    conditions:
+      - conflict
+    actions:
+      label:
+        toggle:
+          - conflict
+
+  - name: Automatic merge on approval
+    conditions:
+      - '#commits-behind=0'
+      - or:
+          - '#approved-reviews-by>=1'
+          - label=ci:auto-merge
+      - not:
+          and:
+            - 'head*=renovate/lockfile-maintenance-*'
+            - 'created-at>24h ago'
+      - base=master
+      - check-success=test-pass
+    actions:
+      merge:
+        method: squash

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,5 +10,10 @@
       ],
       "enabled": false
     }
-  ]
+  ],
+  "labels": [
+    "ci:auto-merge",
+    "dependencies"
+  ],
+  "prConcurrentLimit": 3
 }

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -44,3 +44,10 @@ jobs:
         with:
           files: coverage.out
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  test-pass:
+    needs:
+      - test
+    runs-on: ubuntu-slim
+    steps:
+      - run: echo success


### PR DESCRIPTION
Summary:
- add Mergify configuration and renovate auto-merge rule
- add stable test-pass gate job for matrix tests
- require check-success test-pass
- add Renovate labels ci:auto-merge and dependencies
- set Renovate prConcurrentLimit to 3